### PR TITLE
Fix EOF problem + Any returns earliest match

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -515,7 +515,7 @@ mod tests {
             let mut p = spawn("cat", Some(1000)).expect("cannot run cat");
             p.send_line("Hi")?;
             match p.exp_any(vec![ReadUntil::NBytes(3), ReadUntil::String("Hi".to_string())]) {
-                Ok(s) => assert_eq!(("".to_string(), "Hi\r".to_string()), s),
+                Ok(s) => assert_eq!(("".to_string(), "Hi".to_string()), s),
                 Err(e) => assert!(false, "got error: {}", e),
             }
             Ok(())


### PR DESCRIPTION
Three commits:
1. Run cargo fmt on reader.rs, so that the following commits are less messy

2. Fix the EOF detection, I don't understand this, just a direct copy of https://github.com/philippkeller/rexpect/pull/40. It's included in this PR so that the tests will pass while developing


3. An expectation with Any will now return the leftmost "earliest" match. In case of tie for earliest start, the length of the match is compared, to return the shortest match.
Previously, the match that was higher in the input vector was returned. 
Test was also added for this.
This behavior is the only way to make the results deterministic, since the process might output something like pass ... 1 second pause ... word. If you're matching that towards ["password", "pass"], "pass" should be returned as soon as it is seen. Similar reasoning for why returning the earliest starting match.

If you want me to split this into multiple PRs, just let me know.